### PR TITLE
[bugfix] skip images not found on roda (instead of raising Exception)

### DIFF
--- a/tsd/s2_metadata_parser.py
+++ b/tsd/s2_metadata_parser.py
@@ -191,7 +191,8 @@ def get_roda_metadata(img, filename='tileInfo.json'):
     if r.ok:
         return r.json()
     else:
-        raise Exception("{} not found on roda".format(img.title))
+        print("{} not found on roda".format(img.title, url))
+        return None
 
 
 class Sentinel2Image(dict):
@@ -329,10 +330,14 @@ class Sentinel2Image(dict):
         if 'granule_date' not in self:
             tile_info = get_roda_metadata(self, filename='tileInfo.json')
             #self.granule_date = dateutil.parser.parse(tile_info['timestamp'])
+            if not tile_info:  # abort if file not found on roda
+                return
             self.granule_date = parse_datastrip_id_for_granule_date(tile_info['datastrip']['id'])
 
         if 'absolute_orbit' not in self:
             product_info = get_roda_metadata(self, filename='productInfo.json')
+            if not tile_info:  # abort if file not found on roda
+                return
             self.absolute_orbit = parse_datatake_id_for_absolute_orbit(product_info['datatakeIdentifier'])
 
     #    if self.is_old:

--- a/tsd/s2_metadata_parser.py
+++ b/tsd/s2_metadata_parser.py
@@ -336,7 +336,7 @@ class Sentinel2Image(dict):
 
         if 'absolute_orbit' not in self:
             product_info = get_roda_metadata(self, filename='productInfo.json')
-            if not tile_info:  # abort if file not found on roda
+            if not product_info:  # abort if file not found on roda
                 return
             self.absolute_orbit = parse_datatake_id_for_absolute_orbit(product_info['datatakeIdentifier'])
 


### PR DESCRIPTION
Before this commit the following command would fail because one of the images is not found on roda. Now the files not found are skipped and the valid ones downloaded anyway.
```
python3 tsd/get_sentinel2.py --lat 49.037670 --lon 3.942441 --start-date 2017-09-13 --end-date 2017-09-16 --band B02 B03 B04 B08 --api scihub --product-type L1C -o test
```
(same as pull request https://github.com/cmla/tsd/pull/23 but from the cmla account for Travis)