### PR TITLE
Remove scihub from api choices in get_landsat.py

### DIFF
--- a/tsd/get_landsat.py
+++ b/tsd/get_landsat.py
@@ -91,6 +91,8 @@ def search(aoi, start_date=None, end_date=None, satellite='L8',
     elif api == 'devseed':
         from tsd import search_devseed
         images = search_devseed.search(aoi, start_date, end_date, satellite='Landsat-8')
+    else:
+        raise ValueError('The api "{}" is not available for {}.'.format(api, __file__))
 
     images = [l8_metadata_parser.LandsatImage(img, api) for img in images]
 

--- a/tsd/get_landsat.py
+++ b/tsd/get_landsat.py
@@ -301,7 +301,7 @@ if __name__ == '__main__':
                               ' are {}'.format(', '.join(ALL_BANDS))))
     parser.add_argument('-o', '--outdir', type=str, help=('path to save the '
                                                           'images'), default='')
-    parser.add_argument('--api', type=str, choices=['devseed', 'planet', 'scihub', 'gcloud'],
+    parser.add_argument('--api', type=str, choices=['devseed', 'planet', 'gcloud'],
                         default='devseed', help='search API')
     parser.add_argument('--mirror', type=str, choices=['aws', 'gcloud'],
                         default='gcloud', help='download mirror')


### PR DESCRIPTION
Before, `get_landsat.py` would accept the `scihub` api but then fail:
```
$ python get_landsat.py --lat 35.985077 --lon -96.767698 -o tmp -b B8 -s 2018-08-04 -e 2018-08-05 --api scihub --mirror aws
Traceback (most recent call last):
  File "get_landsat.py", line 340, in <module>
    parallel_downloads=args.parallel_downloads)
  File "get_landsat.py", line 254, in get_time_series
    images = search(aoi, start_date, end_date, satellite, sensor, api=api)
  File "get_landsat.py", line 95, in search
    images = [l8_metadata_parser.LandsatImage(img, api) for img in images]
UnboundLocalError: local variable 'images' referenced before assignment
```
Now it refuses it, or, when directly called from python, fails with this message:
```
Traceback (most recent call last):
  File "get_landsat.py", line 342, in <module>
    parallel_downloads=args.parallel_downloads)
  File "get_landsat.py", line 256, in get_time_series
    images = search(aoi, start_date, end_date, satellite, sensor, api=api)
  File "get_landsat.py", line 95, in search
    raise ValueError('The api "{}" is not available for {}'.format(api, __file__))
ValueError: The api "scihub" is not available for get_landsat.py.
```
