### PR TITLE
get_sentinel2: add B10 in band choices (for L1C images)

### DIFF
--- a/tsd/get_sentinel2.py
+++ b/tsd/get_sentinel2.py
@@ -333,10 +333,10 @@ if __name__ == '__main__':
     parser.add_argument('-e', '--end-date', type=utils.valid_datetime,
                         help='end date, YYYY-MM-DD')
     parser.add_argument('-b', '--band', nargs='*', default=['B04'], metavar='',
-                        choices=s2_metadata_parser.BANDS_L2A + ['all'],
+                        choices=list(set(s2_metadata_parser.BANDS_L2A +  s2_metadata_parser.BANDS_L1C + ['all'])),
                         help=('space separated list of spectral bands to'
                               ' download. Default is B04 (red). Allowed values'
-                              ' are {}'.format(', '.join(s2_metadata_parser.BANDS_L2A))))
+                              ' are {}'.format(', '.join(list(set(s2_metadata_parser.BANDS_L2A + s2_metadata_parser.BANDS_L1C))))))
     parser.add_argument('-o', '--outdir', type=str, help=('path to save the '
                                                           'images'), default='')
     parser.add_argument('--api', type=str, choices=['scihub', 'stac', 'planet', 'gcloud'],


### PR DESCRIPTION
This re-introduces the band B10 in the choices for option `--band`.
The choices were set to the list of available bands for the L2A images of Sentinel-2, now it's the union of available bands for L1C and L2A images.